### PR TITLE
Remove 7.3 platform faking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,6 @@
         "test": "phpunit tests/"
     },
     "config": {
-        "platform": {
-          "php": "7.3"
-        },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": false,
             "phpstan/extension-installer": false


### PR DESCRIPTION
Removes a restriction that fakes a PHP 7.3 environment regardless of the local PHP environment when running `composer require` / `compose update` etc.